### PR TITLE
Fix undefined name issues

### DIFF
--- a/px/environments/demo.py
+++ b/px/environments/demo.py
@@ -36,9 +36,9 @@ import numpy as np
 import px.nmt.environment_client as environment_client
 
 try:
-    raw_input          # Python 2
+  raw_input          # Python 2
 except NameError:
-    raw_input = input  # Python 3
+  raw_input = input  # Python 3
 
 flags.DEFINE_string('server_address', '', 'Address of the environment server.')
 flags.DEFINE_string(

--- a/px/environments/demo.py
+++ b/px/environments/demo.py
@@ -35,6 +35,11 @@ import numpy as np
 
 import px.nmt.environment_client as environment_client
 
+try:
+    raw_input          # Python 2
+except NameError:
+    raw_input = input  # Python 3
+
 flags.DEFINE_string('server_address', '', 'Address of the environment server.')
 flags.DEFINE_string(
     'mode', 'squad',

--- a/px/nmt/utils/logging_utils.py
+++ b/px/nmt/utils/logging_utils.py
@@ -26,6 +26,11 @@ import tensorflow as tf
 
 def safe_string(s):
   """Safely converts unicode and plain strings to byte strings."""
+  try:
+    unicode          # Python 2
+  except NameError:
+    rerurn bytes(s)  # Python 3
+  
   if isinstance(s, unicode):
     try:
       s = s.encode('utf-8')

--- a/px/nmt/utils/logging_utils.py
+++ b/px/nmt/utils/logging_utils.py
@@ -29,7 +29,7 @@ def safe_string(s):
   try:
     unicode          # Python 2
   except NameError:
-    rerurn bytes(s)  # Python 3
+    return bytes(s)  # Python 3
   
   if isinstance(s, unicode):
     try:

--- a/px/nmt/utils/nmt_utils.py
+++ b/px/nmt/utils/nmt_utils.py
@@ -122,7 +122,7 @@ def decode_and_evaluate(name,
   for metric in metrics:
     if metric != "f1" and ref_file:
       if not tf.gfile.Exists(trans_file):
-        raise IOException("%s: translation file not found" % trans_file)
+        raise IOError("%s: translation file not found" % trans_file)
       score = evaluation_utils.evaluate(
           ref_file, trans_file, metric, subword_option=subword_option)
       evaluation_scores[metric] = score


### PR DESCRIPTION

flake8 testing of https://github.com/google/active-qa on Python 3.7.0

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./px/environments/demo.py:55:25: F821 undefined name 'raw_input'
    questions_doc_ids = raw_input(
                        ^
./px/environments/docqa.py:72:20: E999 SyntaxError: invalid syntax
               async=0,
                   ^
./px/nmt/utils/nmt_utils.py:125:15: F821 undefined name 'IOException'
        raise IOException("%s: translation file not found" % trans_file)
              ^
./px/nmt/utils/logging_utils.py:29:20: F821 undefined name 'unicode'
  if isinstance(s, unicode):
                   ^
1     E999 SyntaxError: invalid syntax
3     F821 undefined name 'raw_input'
4
```